### PR TITLE
Adding websockets (ws, wss) support.

### DIFF
--- a/resources/sip11/pom.xml
+++ b/resources/sip11/pom.xml
@@ -69,7 +69,7 @@
 			<dependency>
 				<groupId>javax.sip</groupId>
 				<artifactId>jain-sip-ri</artifactId>
-				<version>1.2.170</version>
+				<version>1.2.232</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/resources/sip11/ra/src/main/java/org/mobicents/slee/resource/sip11/SipResourceAdaptor.java
+++ b/resources/sip11/ra/src/main/java/org/mobicents/slee/resource/sip11/SipResourceAdaptor.java
@@ -213,14 +213,17 @@ public class SipResourceAdaptor implements SipListenerExt,FaultTolerantResourceA
 	public static final int MARSHABLE_ACTIVITY_FLAGS = ActivityFlags.setSleeMayMarshal(NON_MARSHABLE_ACTIVITY_FLAGS);
 	
 	public SipResourceAdaptor() {
-		// Those values are defualt
+		// Those values are default
 		this.port = 5060;
 		// this.transport = "udp";
 		allowedTransports.add("udp");
 		allowedTransports.add("tcp");
-		transports.add("udp");
-		// this.stackAddress = "127.0.0.1";
+        allowedTransports.add("ws");
+        allowedTransports.add("wss");
 
+        transports.add("udp");
+
+        // this.stackAddress = "127.0.0.1";
 		// this.stackPrefix = "gov.nist";
 	}
 

--- a/resources/sip11/ra/src/main/resources/org/mobicents/slee/resource/sip11/sipra.properties
+++ b/resources/sip11/ra/src/main/resources/org/mobicents/slee/resource/sip11/sipra.properties
@@ -26,3 +26,15 @@ gov.nist.javax.sip.MAX_CLIENT_TRANSACTIONS=1000000
 gov.nist.javax.sip.MAX_FORK_TIME_SECONDS=4
 org.mobicents.ha.javax.sip.REPLICATION_STRATEGY=EarlyDialog
 org.mobicents.ha.javax.sip.REPLICATE_APPLICATION_DATA=TRUE
+
+# websockets support
+gov.nist.javax.sip.MESSAGE_PROCESSOR_FACTORY=gov.nist.javax.sip.stack.NioMessageProcessorFactory
+
+# define these to handle the secure bit (wss)
+#
+#javax.net.ssl.keyStore=
+#javax.net.ssl.keyStoreType=
+#javax.net.ssl.keyStorePassword=
+
+#javax.net.ssl.trustStore=
+#javax.net.ssl.trustStoreType=


### PR DESCRIPTION
Patch to include websocket support in the sip-ra.

Please note:
- the included sip-stack version was built with java 1.6 and target 1.6.
- this patch works but has not been extensively tested yet wrt. reliability.

Hope this helps,
Tom.
