### PR TITLE
Fix for issue#23: Default UDP transport makes Contact header constructed incorrectly for TCP transport

### DIFF
--- a/resources/sip11/du/src/main/resources/META-INF/deploy-config.xml
+++ b/resources/sip11/du/src/main/resources/META-INF/deploy-config.xml
@@ -5,6 +5,8 @@
 		entity-name="SipRA">
 		<properties>
 			<property name="javax.sip.PORT" type="java.lang.Integer" value="5060" />
+			<property name="javax.sip.TRANSPORT" type="java.lang.String" value="udp" />
+
 			<!-- the list of SIP balancers, in the form of "HOST:PORT",
 			separated by ";", it is only used if the heart beat service property is defined.
 			In case it is Restcomm SIP Load Balancer and it is configured with 2 ports,

--- a/resources/sip11/ra/src/main/java/org/mobicents/slee/resource/sip11/SipResourceAdaptor.java
+++ b/resources/sip11/ra/src/main/java/org/mobicents/slee/resource/sip11/SipResourceAdaptor.java
@@ -222,8 +222,6 @@ public class SipResourceAdaptor implements SipListenerExt,FaultTolerantResourceA
         allowedTransports.add("ws");
         allowedTransports.add("wss");
 
-        transports.add("udp");
-
         // this.stackAddress = "127.0.0.1";
 		// this.stackPrefix = "gov.nist";
 	}
@@ -1489,6 +1487,7 @@ public class SipResourceAdaptor implements SipListenerExt,FaultTolerantResourceA
 		}
 		
 		this.transportsProperty = (String) properties.getProperty(TRANSPORTS_BIND).getValue();
+		this.transports.clear();
 		for (String transport : this.transportsProperty.split(",")) {
 			this.transports.add(transport);
 		}


### PR DESCRIPTION
This is a proposed fix for the issue described on: https://github.com/RestComm/jain-slee.sip/issues/23
