### PR TITLE
Fix for Can't activate two sip RA entities.

### DIFF
--- a/resources/sip11/ra/pom.xml
+++ b/resources/sip11/ra/pom.xml
@@ -25,6 +25,24 @@
             <groupId>org.mobicents.servers.jainslee.core</groupId>
             <artifactId>fault-tolerant-ra-api</artifactId>			
         </dependency>
+		<!-- For testing purposes -->
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>1.10.19</version>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-api-mockito</artifactId>
+			<version>1.6.5</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-module-junit4</artifactId>
+			<version>1.6.5</version>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
 	
 </project>

--- a/resources/sip11/ra/src/main/java/org/mobicents/slee/resource/sip11/SipResourceAdaptor.java
+++ b/resources/sip11/ra/src/main/java/org/mobicents/slee/resource/sip11/SipResourceAdaptor.java
@@ -1217,8 +1217,24 @@ public class SipResourceAdaptor implements SipListenerExt,FaultTolerantResourceA
 			final Properties properties = new Properties();
 			// load properties for the stack
 			properties.load(getClass().getResourceAsStream("sipra.properties"));
+
+			/* SipFactory recommends not to set javax.sip.IP_ADDRESS: The recommended behaviour is to not specify an
+			 * "javax.sip.IP_ADDRESS" property in the Properties argument, in this case the "javax.sip.STACK_NAME"
+			 * uniquely identifies the stack. A new stack instance will be returned for each different stack name
+			 * associated with a specific vendor implementation. The ListeningPoint is used to configure the IP Address
+			 * argument. or backwards compatability, if a "javax.sip.IP_ADDRESS" is supplied, this method ensures that
+			 * only one instance of a SipStack is returned to the application for that IP Address, independent of the
+			 * number of times this method is called. Different SipStack instances are returned for each different IP
+			 * address.
+			 *
+			 * Let's make sure no javax.sip_IP_ADDRESS is not used for SipStack creation, later on Listening Point will
+			 * be created as per provided IP_ADDRESS .
+			 */
+			if (properties.getProperty(SIP_BIND_ADDRESS) != null) {
+				properties.remove(SIP_BIND_ADDRESS);
+			}
+
 			// now load config properties
-			properties.setProperty(SIP_BIND_ADDRESS, this.stackAddress);
 			// setting the ra entity name as the stack name
 			properties.setProperty(STACK_NAME_BIND, raContext.getEntityName());
 			properties.setProperty(TRANSPORTS_BIND, transportsProperty);
@@ -1619,7 +1635,7 @@ public class SipResourceAdaptor implements SipListenerExt,FaultTolerantResourceA
 		this.sleeEndpoint = null;
 		this.eventLookupFacility = null;
 		this.tracer = null;
-		this.tracer = null;
+		this.providerWrapper = null;
 	}
 
 	/**

--- a/resources/sip11/ra/src/test/java/org/mobicents/slee/resource/sip11/test/SipResourceAdaptorTest.java
+++ b/resources/sip11/ra/src/test/java/org/mobicents/slee/resource/sip11/test/SipResourceAdaptorTest.java
@@ -1,0 +1,144 @@
+package org.mobicents.slee.resource.sip11.test;
+
+import javax.sip.ListeningPoint;
+import javax.slee.facilities.Tracer;
+import javax.slee.resource.ConfigProperties;
+import javax.slee.resource.ConfigProperties.Property;
+import javax.slee.resource.ResourceAdaptorContext;
+
+import org.mobicents.ha.javax.sip.ClusteredSipStack;
+import org.mobicents.slee.resource.sip11.SipResourceAdaptor;
+import org.mobicents.slee.resource.sip11.SleeSipProviderImpl;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.BeforeClass;
+
+import org.powermock.reflect.Whitebox;
+
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+import org.mockito.stubbing.*;
+import org.mockito.invocation.*;
+import java.util.Arrays;
+import java.util.Iterator;
+
+public class SipResourceAdaptorTest {
+
+    private  static final int SIP_RA1_PORT = 5060;
+	private static final int SIP_RA2_PORT = 5059;
+	private static final String STACK_ADDRESS = "127.0.0.1";
+    // common mocked tracer
+	private static Tracer tracer1 = mock(Tracer.class);
+
+	// resource adaptor context
+	private static ResourceAdaptorContext raContext1 = mock(ResourceAdaptorContext.class);
+	private static ResourceAdaptorContext raContext2 = mock(ResourceAdaptorContext.class);
+
+	// slee sip provider mock
+	private static SleeSipProviderImpl sleeSipProvider = mock(SleeSipProviderImpl.class);
+
+	// minimal mock just to satisfy SipResourceAdaptor's usage of the tracer
+	private static void mockTracer() {
+		// mock info() call for tracer
+		Answer<Object> answer = new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation) {
+				System.out.println(" (TRACER-MOCK) :: info() called :: " + Arrays.toString(invocation.getArguments()));
+				return null;
+			}
+		};
+		doAnswer(answer).when(tracer1).info(anyString());
+	}
+
+	// minimal mock just to satisfy SipResourceAdaptor's usage of the tracer
+	private static void mockRaContext() {
+		when(raContext1.getEntityName()).thenReturn("stack#1");
+		when(raContext2.getEntityName()).thenReturn("stack#2");
+	}
+
+	@BeforeClass
+	public static void prepareEnvSharedByAllTests() {
+		mockTracer();
+		mockRaContext();
+	}
+
+	@Test
+	/*
+	 * Purpose of this test it to verify whether two RA entities can be activated on the
+	 * same network interface within same class loader.
+	 */
+	public void testActivateTwoRaEntities() {
+		// create two RAs
+		SipResourceAdaptor ra1 = new SipResourceAdaptor();
+		SipResourceAdaptor ra2 = new SipResourceAdaptor();
+
+		// initialize internal dependencies of RA#1
+		Whitebox.setInternalState(ra1, "tracer", tracer1);
+		Whitebox.setInternalState(ra1, "raContext", raContext1);
+		Whitebox.setInternalState(ra1, "providerWrapper", sleeSipProvider);
+
+		// initialize internal dependencies of RA#2
+		Whitebox.setInternalState(ra2, "tracer", tracer1);
+		Whitebox.setInternalState(ra2, "raContext", raContext2);
+		Whitebox.setInternalState(ra2, "providerWrapper", sleeSipProvider);
+
+		// prepare configuration for RA#1, RA#2
+		ConfigProperties configRa1 = new ConfigProperties();
+		ConfigProperties configRa2;
+
+		configRa1.addProperty(new Property("javax.sip.TRANSPORT", "java.lang.String", "TCP"));
+		configRa1.addProperty(new Property("javax.sip.IP_ADDRESS", "java.lang.String", STACK_ADDRESS));
+		configRa1.addProperty(new Property("org.mobicents.ha.javax.sip.BALANCERS", "java.lang.String", ""));
+		configRa1.addProperty(new Property("org.mobicents.ha.javax.sip.LoadBalancerHeartBeatingServiceClassName",
+				"java.lang.String", "org.mobicents.ha.javax.sip.LoadBalancerHeartBeatingServiceImpl"));
+		configRa1.addProperty(new Property("org.mobicents.ha.javax.sip.LoadBalancerElector", "java.lang.String",
+				"org.mobicents.ha.javax.sip.RoundRobinLoadBalancerElector"));
+		configRa1.addProperty(new Property("org.mobicents.ha.javax.sip.CACHE_CLASS_NAME", "java.lang.String",
+				"org.mobicents.ha.javax.sip.cache.NoCache"));
+
+		// clone common properties
+		configRa2 = (ConfigProperties) configRa1.clone();
+
+		// RA#1 custom configuration
+		configRa1.addProperty(new Property("javax.sip.PORT", "java.lang.Integer", SIP_RA1_PORT));
+		configRa1.addProperty(new Property("javax.sip.STACK_NAME", "java.lang.String", raContext1.getEntityName()));
+
+		// RA#2 custom configuration
+		configRa2.addProperty(new Property("javax.sip.PORT", "java.lang.Integer", SIP_RA2_PORT));
+		configRa2.addProperty(new Property("javax.sip.STACK_NAME", "java.lang.String", raContext2.getEntityName()));
+
+		// configure adaptors
+		ra1.raConfigure(configRa1);
+		Assert.assertEquals(SIP_RA1_PORT, Whitebox.getInternalState(ra1, "port"));
+		Assert.assertEquals(STACK_ADDRESS, Whitebox.getInternalState(ra1, "stackAddress"));
+
+		ra2.raConfigure(configRa2);
+		Assert.assertEquals(SIP_RA2_PORT, Whitebox.getInternalState(ra2, "port"));
+		Assert.assertEquals(STACK_ADDRESS, Whitebox.getInternalState(ra2, "stackAddress"));
+
+		ra1.raActive();
+		ra2.raActive();
+
+		// verify RA1 stack
+		ClusteredSipStack stack1 = Whitebox.getInternalState(ra1, "sipStack");
+		Assert.assertEquals(raContext1.getEntityName(),stack1.getStackName());
+
+		// verify that RA1 - stack is listening on a port used in configuration
+		Iterator stack1ListeningPoints = stack1.getListeningPoints();
+		while (stack1ListeningPoints.hasNext()) {
+			ListeningPoint listeningPoint = (ListeningPoint) stack1ListeningPoints.next();
+			Assert.assertEquals(SIP_RA1_PORT,listeningPoint.getPort());
+		}
+
+		// verify RA2 stack
+		ClusteredSipStack stack2 = Whitebox.getInternalState(ra2, "sipStack");
+		Assert.assertEquals(raContext2.getEntityName(),stack2.getStackName());
+
+		// verify that RA2 - stack is listening on a port used in configuration
+		Iterator<ListeningPoint> stack2ListeningPoints = stack1.getListeningPoints();
+		while (stack1ListeningPoints.hasNext()) {
+			ListeningPoint listeningPoint = (ListeningPoint) stack1ListeningPoints.next();
+			Assert.assertEquals(SIP_RA2_PORT,listeningPoint.getPort());
+		}
+    }
+}


### PR DESCRIPTION
This is a proposed fix for issue/27. 

Class loading influence might be a separate thing, and it can cover the root cause of SIP RA issue. If SIP RA entities are created from different class loaders, then the issue may not appear.  

SipFactory is a singleton and it keeps track of existing SipStack instances created by SipFactory, basically the same stack instance is returned in case:
a) sip stack's name (provided in Properties) matches the name of one of already created stacks
b) sip stack's IP (provided in Properties) matches IP of already cretead stacks

SipFactory first relies on javax.sip.IP_ADDRESS, then on javax.sip.STACK_NAME.  

Since SipResourceAdaptor provided javax.sip.IP_ADDRESS, then the same stack was returned by SipFactory, but later on in raActive(), new provider  and listener were created and added to existing stack (which already had provider/listener set).

Now, different class loaders implies different singletons (SipFactory) created. The other singleton knows nothing about first stack crated, thus it will create a new stack.

The fix just removes IP_ADDRESS from properties passed to SipFactory. Still it allows to create a listening point passed to RA configuration. 

There is a unit test provided to verify the fix. 
