### PR TITLE
DialogWrapper.delete() - NullPointerException

### DIFF
--- a/resources/sip11/ra/src/main/java/org/mobicents/slee/resource/sip11/wrappers/DialogWrapper.java
+++ b/resources/sip11/ra/src/main/java/org/mobicents/slee/resource/sip11/wrappers/DialogWrapper.java
@@ -501,9 +501,17 @@ public class DialogWrapper extends Wrapper implements DialogActivity {
 		}
 		
 		final DialogState currentState = wrappedDialog != null ? wrappedDialog.getState() : null;
+		boolean isServerFlag = wrappedDialog != null ? wrappedDialog.isServer() : false; // is false ok, here?
 		boolean stackDoesNotFiresDialogTerminatedEvent = !isEnding()
-			&& !wrappedDialog.isServer() && (currentState == null || currentState == DialogState.TERMINATED);
-		wrappedDialog.delete();
+			&& !isServerFlag && (currentState == null || currentState == DialogState.TERMINATED);
+
+		if (wrappedDialog != null) {
+			wrappedDialog.delete();
+		} else {
+			if (tracer.isFineEnabled()) {
+				tracer.fine("wrappedDialog is not set, skipping deletion.");
+			}
+		}
 		if (stackDoesNotFiresDialogTerminatedEvent) {
 			ra.processDialogTerminated(this);
 		}


### PR DESCRIPTION
delete() now considers case when wrappedDialog object is not present. This is a fix for https://github.com/RestComm/jain-slee.sip/issues/25
