### PR TITLE
Fix for incorrect key used for map retrieval.

### DIFF
--- a/resources/sip11/ra/src/main/java/org/mobicents/slee/resource/sip11/SleeSipProviderImpl.java
+++ b/resources/sip11/ra/src/main/java/org/mobicents/slee/resource/sip11/SleeSipProviderImpl.java
@@ -162,7 +162,7 @@ public class SleeSipProviderImpl implements SleeSipProvider {
 	 */
 	public SipURI getLocalSipURI(String transport) {
 		checkState();
-		SipUri sipURI = localSipURIs.get(localSipURIs);
+		SipUri sipURI = localSipURIs.get(transport);
 		if (sipURI == null) {
 			ListeningPoint lp = getListeningPoint(transport);
 			if (lp != null) {


### PR DESCRIPTION
In SleeSipProvider implementation getLocalSipURI uses incorrect key for retrieval of SipUri.

Incorrect statement:
SipUri sipURI = localSipURIs.get(localSipURIs);

The problem is localSipURIs is ConcurrentHashMap<String, SipUri>. 